### PR TITLE
Fix caching issues & avoid page transition after new conversation is started

### DIFF
--- a/client/web/app/[workspaceId]/ConversationList.tsx
+++ b/client/web/app/[workspaceId]/ConversationList.tsx
@@ -26,7 +26,7 @@ const ConversationList = ({
   const loadingRef = useRef<HTMLDivElement>(null);
 
   const { data, fetchNextPage, isFetching, hasNextPage } = useInfiniteQuery({
-    queryKey: ["conversations", workspaceId, searchQuery],
+    queryKey: ["conversations", workspaceId, searchQuery, initialConversations],
     initialData: isSearch
       ? {
           pages: [],

--- a/client/web/app/[workspaceId]/DeleteConversationModal.tsx
+++ b/client/web/app/[workspaceId]/DeleteConversationModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { revalidateConversations } from "@/app/actions";
+import { revalidateAll } from "@/app/actions";
+import { queryClient } from "@/components/QueryClientProvider";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -48,7 +49,11 @@ export default function DeleteConversationModal({
         }),
       });
       if (response.ok) {
-        revalidateConversations();
+        await revalidateAll();
+        queryClient.invalidateQueries({
+          queryKey: ["conversations", workspaceId],
+          type: "all",
+        });
         push(`/${workspaceId}`);
         refresh();
         emitter.emit("updateSidebar");

--- a/client/web/app/[workspaceId]/Sidebar.tsx
+++ b/client/web/app/[workspaceId]/Sidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import PageTransitionLink from "@/components/PageTransitionLink";
+import QueryClientProvider, { queryClient } from "@/components/QueryClientProvider";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import {
@@ -12,7 +13,6 @@ import {
 import emitter from "@/lib/eventEmitter";
 import { ConversationModel, WorkspaceModel } from "@/lib/sesameApi";
 import { cn } from "@/lib/utils";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Edit, LayoutGridIcon, LoaderCircleIcon } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 import {
@@ -25,8 +25,6 @@ import {
 import ConversationList from "./ConversationList";
 import SearchResults from "./SearchResults";
 import SidebarTitle from "./SidebarTitle";
-
-const queryClient = new QueryClient();
 
 interface SidebarProps {
   conversations: ConversationModel[];
@@ -51,6 +49,7 @@ export default function Sidebar({
     const updateSidebar = () =>
       queryClient.invalidateQueries({
         queryKey: ["conversations", workspace?.workspace_id],
+        type: "all",
       });
     const handleResize = () => {
       if (window.innerWidth >= 1024) setIsOpen(false);
@@ -122,7 +121,7 @@ export default function Sidebar({
         onChange={(ev) => setSearch(ev.target.value)}
       />
 
-      <QueryClientProvider client={queryClient}>
+      <QueryClientProvider>
         {workspace ? (
           deferredSearch ? (
             <Suspense

--- a/client/web/app/[workspaceId]/layout.tsx
+++ b/client/web/app/[workspaceId]/layout.tsx
@@ -1,6 +1,7 @@
 "use server";
 
 import ErrorPage from "@/components/ErrorPage";
+import QueryClientProvider from "@/components/QueryClientProvider";
 import { WorkspaceWithConversations } from "@/lib/sesameApi";
 import { getWorkspaces } from "@/lib/workspaces";
 import { redirect } from "next/navigation";
@@ -59,10 +60,12 @@ export default async function WorkspaceLayout({
         </main>
       </div>
 
-      <DeleteConversationModal
-        conversations={workspace.conversations}
-        workspaceId={workspaceId}
-      />
+      <QueryClientProvider>
+        <DeleteConversationModal
+          conversations={workspace.conversations}
+          workspaceId={workspaceId}
+        />
+      </QueryClientProvider>
       <DisabledInSandboxModeModal />
     </div>
   );

--- a/client/web/app/actions.ts
+++ b/client/web/app/actions.ts
@@ -8,7 +8,7 @@ export async function revalidateConversations() {
 
 export async function revalidateConversation(conversationId: string) {
   revalidateTag(conversationId);
-  revalidateConversations();
+  await revalidateConversations();
 }
 
 export async function revalidateWorkspaces() {
@@ -18,4 +18,9 @@ export async function revalidateWorkspaces() {
 export async function revalidateWorkspace(workspaceId: string) {
   revalidateTag(workspaceId);
   revalidateWorkspaces();
+}
+
+export async function revalidateAll() {
+  await revalidateWorkspaces();
+  await revalidateConversations();
 }

--- a/client/web/app/api/create-conversation/route.ts
+++ b/client/web/app/api/create-conversation/route.ts
@@ -1,4 +1,4 @@
-import { revalidateConversations } from "@/app/actions";
+import { revalidateAll } from "@/app/actions";
 import { getApiClient } from "@/lib/sesameApiClient";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -17,7 +17,7 @@ export async function POST(request: NextRequest) {
 
     const json = await response.json();
 
-    revalidateConversations();
+    await revalidateAll();
 
     return NextResponse.json(json);
   } catch (error) {

--- a/client/web/app/api/create-workspace/route.ts
+++ b/client/web/app/api/create-workspace/route.ts
@@ -1,4 +1,4 @@
-import { revalidateWorkspaces } from "@/app/actions";
+import { revalidateAll } from "@/app/actions";
 import { WorkspaceModel } from "@/lib/sesameApi";
 import { getApiClient } from "@/lib/sesameApiClient";
 import { NextRequest, NextResponse } from "next/server";
@@ -16,7 +16,7 @@ export async function POST(request: NextRequest) {
     if (response.ok) {
       const json = await response.json();
 
-      revalidateWorkspaces();
+      await revalidateAll();
 
       return NextResponse.json(json);
     } else {

--- a/client/web/app/api/delete-conversation/route.ts
+++ b/client/web/app/api/delete-conversation/route.ts
@@ -1,4 +1,4 @@
-import { revalidateConversations } from "@/app/actions";
+import { revalidateAll } from "@/app/actions";
 import { getApiClient } from "@/lib/sesameApiClient";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -14,7 +14,7 @@ export async function DELETE(request: NextRequest) {
 
     const json = await response.json();
 
-    revalidateConversations();
+    await revalidateAll();
 
     return NextResponse.json(json);
   } catch (error) {

--- a/client/web/app/api/delete-workspace/route.ts
+++ b/client/web/app/api/delete-workspace/route.ts
@@ -1,4 +1,4 @@
-import { revalidateWorkspaces } from "@/app/actions";
+import { revalidateAll } from "@/app/actions";
 import { getApiClient } from "@/lib/sesameApiClient";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -14,7 +14,7 @@ export async function DELETE(request: NextRequest) {
 
     const json = await response.json();
 
-    revalidateWorkspaces();
+    await revalidateAll();
 
     return NextResponse.json(json);
   } catch (error) {

--- a/client/web/app/api/update-conversation/route.ts
+++ b/client/web/app/api/update-conversation/route.ts
@@ -1,4 +1,4 @@
-import { revalidateConversation } from "@/app/actions";
+import { revalidateAll } from "@/app/actions";
 import { getApiClient } from "@/lib/sesameApiClient";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -17,7 +17,7 @@ export async function PUT(request: NextRequest) {
 
     const json = await response.json();
 
-    revalidateConversation(conversation_id);
+    await revalidateAll();
 
     return NextResponse.json(json);
   } catch (error) {

--- a/client/web/app/api/update-workspace/route.ts
+++ b/client/web/app/api/update-workspace/route.ts
@@ -1,4 +1,4 @@
-import { revalidateWorkspace } from "@/app/actions";
+import { revalidateAll } from "@/app/actions";
 import { WorkspaceModel } from "@/lib/sesameApi";
 import { getApiClient } from "@/lib/sesameApiClient";
 import { NextRequest, NextResponse } from "next/server";
@@ -20,7 +20,7 @@ export async function PUT(request: NextRequest) {
     if (response.ok) {
       const json = await response.json();
 
-      revalidateWorkspace(workspace.workspace_id);
+      await revalidateAll();
 
       return NextResponse.json(json);
     } else {

--- a/client/web/components/ClientPage.tsx
+++ b/client/web/components/ClientPage.tsx
@@ -3,6 +3,7 @@
 import AutoScrollToBottom from "@/components/AutoScrollToBottom";
 import ChatControls from "@/components/ChatControls";
 import PageRefresher from "@/components/PageRefresher";
+import QueryClientProvider from "@/components/QueryClientProvider";
 import Logo from "@/components/svg/Logo";
 import { Button } from "@/components/ui/button";
 import {
@@ -13,6 +14,7 @@ import {
 } from "@/components/ui/tooltip";
 import emitter from "@/lib/eventEmitter";
 import type { Message } from "@/lib/messages";
+import { cn } from "@/lib/utils";
 import { WorkspaceStructuredData } from "@/lib/workspaces";
 import { ArrowDownIcon } from "lucide-react";
 import { useSearchParams } from "next/navigation";
@@ -93,73 +95,81 @@ export default function ClientPage({
     };
   }, []);
 
+  const animate = !searchParams.has("a") || searchParams.get("a") === "1";
+
   return (
     <RTVIClientProvider client={client!}>
-      <PageRefresher />
-      <div className="animate-appear flex flex-col justify-between flex-grow">
-        <AutoScrollToBottom />
+      <QueryClientProvider>
+        <PageRefresher />
+        <div
+          className={cn("flex flex-col justify-between flex-grow", {
+            "animate-appear": animate,
+          })}
+        >
+          <AutoScrollToBottom />
 
-        {/* Messages */}
-        <div className="relative flex-grow p-4 flex flex-col">
-          {messages.length > 0 || showMessages ? (
-            <ChatMessages
-              autoscroll={!showScrollToBottom}
+          {/* Messages */}
+          <div className="relative flex-grow p-4 flex flex-col">
+            {messages.length > 0 || showMessages ? (
+              <ChatMessages
+                autoscroll={!showScrollToBottom}
+                conversationId={conversationId}
+                messages={messages}
+                structuredWorkspace={structuredWorkspace}
+                workspaceId={workspaceId}
+              />
+            ) : (
+              <div className="flex flex-col gap-4 items-center justify-center h-full my-auto">
+                <div className="relative z-10 flex items-center justify-center size-16 bg-primary rounded-full">
+                  <Logo className="text-white size-8 rotate-12" />
+                </div>
+                <h2 className="font-semibold text-xl text-center">
+                  Start chatting
+                </h2>
+              </div>
+            )}
+            {showScrollToBottom && (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      className="rounded-full fixed right-4 bottom-20 z-20"
+                      onClick={() =>
+                        document.scrollingElement?.scrollTo({
+                          behavior: "smooth",
+                          top: document.scrollingElement?.scrollHeight,
+                        })
+                      }
+                      size="icon"
+                      variant="outline"
+                    >
+                      <ArrowDownIcon size={16} />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent
+                    align="center"
+                    className="bg-popover text-popover-foreground"
+                    side="left"
+                  >
+                    Scroll to bottom
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
+          </div>
+
+          {/* Chat controls */}
+          <div className="bg-background sticky bottom-0 z-10">
+            <ChatControls
               conversationId={conversationId}
-              messages={messages}
-              structuredWorkspace={structuredWorkspace}
               workspaceId={workspaceId}
             />
-          ) : (
-            <div className="flex flex-col gap-4 items-center justify-center h-full my-auto">
-              <div className="relative z-10 flex items-center justify-center size-16 bg-primary rounded-full">
-                <Logo className="text-white size-8 rotate-12" />
-              </div>
-              <h2 className="font-semibold text-xl text-center">
-                Start chatting
-              </h2>
-            </div>
-          )}
-          {showScrollToBottom && (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    className="rounded-full fixed right-4 bottom-20 z-20"
-                    onClick={() =>
-                      document.scrollingElement?.scrollTo({
-                        behavior: "smooth",
-                        top: document.scrollingElement?.scrollHeight,
-                      })
-                    }
-                    size="icon"
-                    variant="outline"
-                  >
-                    <ArrowDownIcon size={16} />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent
-                  align="center"
-                  className="bg-popover text-popover-foreground"
-                  side="left"
-                >
-                  Scroll to bottom
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          )}
+          </div>
         </div>
 
-        {/* Chat controls */}
-        <div className="bg-background sticky bottom-0 z-10">
-          <ChatControls
-            conversationId={conversationId}
-            workspaceId={workspaceId}
-          />
-        </div>
-      </div>
-
-      <RTVIClientAudio />
-      <Settings conversationId={conversationId} workspaceId={workspaceId} />
+        <RTVIClientAudio />
+        <Settings conversationId={conversationId} workspaceId={workspaceId} />
+      </QueryClientProvider>
     </RTVIClientProvider>
   );
 }

--- a/client/web/components/QueryClientProvider.tsx
+++ b/client/web/components/QueryClientProvider.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import {
+  QueryClient,
+  QueryClientProvider as TanStackQueryProvider,
+} from "@tanstack/react-query";
+
+export const queryClient = new QueryClient();
+
+type Props = React.PropsWithChildren;
+
+export default function QueryClientProvider({ children }: Props) {
+  return (
+    <TanStackQueryProvider client={queryClient}>
+      {children}
+    </TanStackQueryProvider>
+  );
+}


### PR DESCRIPTION
# Short summary of changes

This makes the transition from creating a new conversation (`/:workspaceId` -> `/:workspaceId/c/:conversationId`) seamless.
It also fixes some caching issues when creating and deleting conversations, making sure that both client- and server-side caches are revalidated accordingly.