### PR TITLE
Replace database URL in env with individual credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,18 +38,17 @@ cp server/env.example server/.env
 
 You must set the following:
 
-`SESAME_DATABASE_ADMIN_URL`
-
-Database superuser credentials (i.e. Supabase URI on port `5432`.) _Note: Must support asyncpg or equivalent asychnronous driver._
-
-> 🛑 Ensure you are using a database URL on a session port (typically `5432`) If you are using Supabase, the URL provided in the settings panel defaults to "transaction mode". See [Database setup](#database-setup) for details.
-
-You database URL should look something like:
-
 ```bash
-SESAME_DATABASE_ADMIN_URL="postgresql://postgres.ID:PASSWORD@aws-0-us-west-1.pooler.supabase.com:5432/postgres"
-# Note port 5432, not 6543
+SESAME_DATABASE_ADMIN_USER
+SESAME_DATABASE_ADMIN_PASSWORD
+SESAME_DATABASE_NAME
+SESAME_DATABASE_HOST
+SESAME_DATABASE_PORT
 ```
+
+Set these to your superuser credentials. _Note: Your database must support asyncpg or equivalent asychnronous driver._
+
+> 🛑 Ensure you are using a database that accepts session mode typically available on port `5432`. If you are using Supabase, the URL provided in the settings panel defaults to "transaction mode". See [Database setup](#database-setup) for details.
 
 #### 3. Create database roles and schema
 
@@ -63,9 +62,7 @@ Note: the `run_schema.sh` script requires Postgres to run. Install the necessary
 
 If the schema runs correctly, the script will print out a non-superuser URL to the terminal which you should add to your environment.
 
-Add `SESAME_DATABASE_URL` in `server/.env` with the output of the script.
-
-> 🛑 If your admin database password includes "@" characters, the bash script may fail to correctly replace the `SESAME_DATABASE_URL` password using `sed`. In this scenario, please manually adjust.
+Add `SESAME_DATABASE_USER` and `SESAME_DATABASE_PASSWORD` in `server/.env` with the output of the script.
 
 For more information about database configuration, read [here](#database-setup)
 
@@ -111,20 +108,25 @@ _Note: Sesame bots are configured to use [Daily](https://www.daily.co) as a tran
 
 ### Database setup
 
-Sesame works with most types of database. If you are using Supabase, there are no additional setup steps required. If not, you may need to install additional extensions specified in [database/schema.sql](./database/schema.sql).
+Sesame works with most types of database. You may need to install additional extensions specified in [database/schema.sql](./database/schema.sql).
 
 #### 1. Update your .env
 
-Update`SESAME_DATABASE_ADMIN_URL` (admin) in `server/.env`.
+Update the non-optional `SESAME_DATABASE_*` variables in `server/.env`.
 
-For Supabase can find your URL here: https://supabase.com/dashboard/project/[YOUR_PROJECT]/settings/database. **Note: be sure to use the URI for `Mode: session`.**
+For Supabase, for example, you can find credentials URL here: https://supabase.com/dashboard/project/[YOUR_PROJECT]/settings/database. **Note: be sure to use the URI for `Mode: session` to get the correct port for session mode.**
 
 ![](./docs/supabaseurl.png)
 
-Your database URI should look something like this:
+Your database credentials should look something like this:
 
 ```bash
-SESAME_DATABASE_ADMIN_URL=postgresql://postgres.user:pass@region.pooler.supabase.com:5432/postgres
+SESAME_DATABASE_ADMIN_USER="postgres"
+SESAME_DATABASE_ADMIN_PASSWORD="password"
+SESAME_DATABASE_NAME="postgres"
+SESAME_DATABASE_HOST="egion.pooler.supabase.com"
+# - Use a session port (typically 5432)
+SESAME_DATABASE_PORT=5432
 ```
 
 #### 2. Apply database schema
@@ -135,7 +137,7 @@ This script will create the necessary tables, functions and triggers, as well ec
 
 #### 3. Update your .env with the public database URL
 
-Update`SESAME_DATABASE_URL` (public) in `server/.env` with the randomly generated password created by the `run_schema` script.
+Update`SESAME_DATABASE_USER` and `SESAME_DATABASE_PASSWORD` (public) in `server/.env` with the randomly generated password created by the `run_schema` script.
 
 Alternatively, you can set this yourself in `database/schema.sql` by changing the `%%REPLACED%%` input near the bottom.
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ _Note: Sesame bots are configured to use [Daily](https://www.daily.co) as a tran
 
 ### Database setup
 
-Sesame works with most types of database. You may need to install additional extensions specified in [database/schema.sql](./database/schema.sql).
+Sesame requires a Postgres database (support for other database types, such as SQLLite, coming soon). You may need to install additional extensions specified in [database/schema.sql](./database/schema.sql).
 
 #### 1. Update your .env
 
@@ -124,7 +124,7 @@ Your database credentials should look something like this:
 SESAME_DATABASE_ADMIN_USER="postgres"
 SESAME_DATABASE_ADMIN_PASSWORD="password"
 SESAME_DATABASE_NAME="postgres"
-SESAME_DATABASE_HOST="egion.pooler.supabase.com"
+SESAME_DATABASE_HOST="region.pooler.supabase.com"
 # - Use a session port (typically 5432)
 SESAME_DATABASE_PORT=5432
 ```

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ You should see a URL in your terminal window to visit, for example `http://127.0
 
 <img alt="open-sesame-dashboard" width="280px" height="auto" src="./docs/sesame-dashboard.png">
 
-Log in with the user name and password you set in step 4.
+Log in with the user name and password you set in step 5.
 
 Now, create a new access token to authenticate web requests in any of the Open Sesame clients. For more information, see [authentication](./docs/authentication.md).
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,16 @@ source venv/bin/activate # ... or OS specific activation
 pip install -r server/dev-requirements.txt
 ```
 
-#### 2. Create a local .env
+#### 2. Create a database
+
+Sesame uses data storage for users, workspace settings and conversation history. The default schema uses PSQL.
+
+Create a new local database: `psql -U postgres -c "CREATE DATABASE sesame;"`
+
+... or alternatively, use a hosted provider such as [Render](www.render.com) or [Supabase](www.supabase.com).
+
+
+#### 3. Create a local .env
 
 ```shell
 cp server/env.example server/.env
@@ -50,7 +59,7 @@ Set these to your superuser credentials. _Note: Your database must support async
 
 > 🛑 Ensure you are using a database that accepts session mode typically available on port `5432`. If you are using Supabase, the URL provided in the settings panel defaults to "transaction mode". See [Database setup](#database-setup) for details.
 
-#### 3. Create database roles and schema
+#### 4. Create database roles and schema
 
 From the root of the project, run the schema script found in [scripts/run_shema.sh](./scripts/run_schema.sh)
 
@@ -60,13 +69,13 @@ bash scripts/run_schema.sh
 
 Note: the `run_schema.sh` script requires Postgres to run. Install the necessary package for your system (e.g. `brew install postgresql` for MacOS).
 
-If the schema runs correctly, the script will print out a non-superuser URL to the terminal which you should add to your environment.
+If the schema runs correctly, the script will print out a non-superuser user and password.
 
-Add `SESAME_DATABASE_USER` and `SESAME_DATABASE_PASSWORD` in `server/.env` with the output of the script.
+Edit `SESAME_DATABASE_USER` and `SESAME_DATABASE_PASSWORD` in `server/.env` with the output of the script.
 
 For more information about database configuration, read [here](#database-setup)
 
-#### 4. Create a user
+#### 5. Create a user
 
 From the root of the project still, create a user account and password from [scripts/create_user.sh](./scripts/create_user.sh).
 
@@ -76,7 +85,7 @@ bash scripts/create_user.sh
 
 Running this script will create a user account in your database. Make a note of your username and password; the password will be encrypted and not recoverable later.
 
-#### 5. Run the Sesame server and generate access token
+#### 6. Run the Sesame server and generate access token
 
 ```shell
 cd server/
@@ -91,7 +100,7 @@ Log in with the user name and password you set in step 4.
 
 Now, create a new access token to authenticate web requests in any of the Open Sesame clients. For more information, see [authentication](./docs/authentication.md).
 
-#### 6. Create your first workspace
+#### 7. Create your first workspace
 
 Follow the [workspace creation steps](#create-your-first-workspace), and run a [client](#run-a-client-app) of your choosing.
 
@@ -108,7 +117,7 @@ _Note: Sesame bots are configured to use [Daily](https://www.daily.co) as a tran
 
 ### Database setup
 
-Sesame requires a Postgres database (support for other database types, such as SQLLite, coming soon). You may need to install additional extensions specified in [database/schema.sql](./database/schema.sql).
+Sesame requires a Postgres database (support for other database types, such as SQLite, coming soon). You may need to install additional extensions specified in [database/schema.sql](./database/schema.sql).
 
 #### 1. Update your .env
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ pip install -r server/dev-requirements.txt
 
 #### 2. Create a database
 
-Sesame uses data storage for users, workspace settings and conversation history. The default schema uses PSQL.
+Sesame uses data storage for users, workspace settings and conversation history. The current default schema assumes Postgres.
 
 Create a new local database: `psql -U postgres -c "CREATE DATABASE sesame;"`
 
-... or alternatively, use a hosted provider such as [Render](www.render.com) or [Supabase](www.supabase.com).
+... or alternatively, use a hosted database provider such as [Render](www.render.com) or [Supabase](www.supabase.com).
 
 
 #### 3. Create a local .env
@@ -48,14 +48,15 @@ cp server/env.example server/.env
 You must set the following:
 
 ```bash
-SESAME_DATABASE_ADMIN_USER
-SESAME_DATABASE_ADMIN_PASSWORD
-SESAME_DATABASE_NAME
-SESAME_DATABASE_HOST
-SESAME_DATABASE_PORT
+SESAME_APP_SECRET # For data encryption
+SESAME_DATABASE_ADMIN_USER # Privileged database user
+SESAME_DATABASE_ADMIN_PASSWORD # Privileged user password
+SESAME_DATABASE_NAME # E.g. sesame
+SESAME_DATABASE_HOST # E.g. localhost
+SESAME_DATABASE_PORT # E.g. 5432
 ```
 
-Set these to your superuser credentials. _Note: Your database must support asyncpg or equivalent asychnronous driver._
+_Note: Your database must support asyncpg or equivalent asychnronous driver._
 
 > 🛑 Ensure you are using a database that accepts session mode typically available on port `5432`. If you are using Supabase, the URL provided in the settings panel defaults to "transaction mode". See [Database setup](#database-setup) for details.
 
@@ -100,9 +101,17 @@ Log in with the user name and password you set in step 4.
 
 Now, create a new access token to authenticate web requests in any of the Open Sesame clients. For more information, see [authentication](./docs/authentication.md).
 
-#### 7. Create your first workspace
+#### 7. Run the tests to check your configuration
+
+```bash
+cd server/
+PYTHONPATH=. pytest tests/ -s -v
+```
+
+#### 8. Create your first workspace
 
 Follow the [workspace creation steps](#create-your-first-workspace), and run a [client](#run-a-client-app) of your choosing.
+
 
 ## Overview
 

--- a/scripts/create_user.sh
+++ b/scripts/create_user.sh
@@ -10,12 +10,13 @@ else
   exit 1
 fi
 
-# Check if SESAME_DATABASE_ADMIN_URL (for anon_user) is set
-if [ -z "$SESAME_DATABASE_ADMIN_URL" ]; then
-  echo "SESAME_DATABASE_ADMIN_URL is not set in .env file. Please set it."
+# Check for database credetials
+if [ -z "$SESAME_DATABASE_ADMIN_USER" ] || [ -z "$SESAME_DATABASE_ADMIN_PASSWORD" ] || [ -z "$SESAME_DATABASE_NAME" ] || [ -z "$SESAME_DATABASE_HOST" ] || [ -z "$SESAME_DATABASE_PORT" ]; then
+  echo "One or more required environment variables are not set in .env file. Please set them."
   exit 1
 fi
 
+SESAME_DATABASE_ADMIN_URL="$SESAME_DATABASE_PROTOCOL://$SESAME_DATABASE_ADMIN_USER:$SESAME_DATABASE_ADMIN_PASSWORD@$SESAME_DATABASE_HOST:$SESAME_DATABASE_PORT/$SESAME_DATABASE_NAME"
 
 # Prompt for username
 while true; do

--- a/scripts/run_schema.sh
+++ b/scripts/run_schema.sh
@@ -12,22 +12,24 @@ else
   exit 1
 fi
 
-# Check if SESAME_DATABASE_ADMIN_URL (for anon_user) is set
-if [ -z "$SESAME_DATABASE_ADMIN_URL" ]; then
-  echo "SESAME_DATABASE_ADMIN_URL is not set in .env file. Please set it."
+# Check if necessary database vars (for admin user) is set
+if [ -z "$SESAME_DATABASE_ADMIN_USER" ] || [ -z "$SESAME_DATABASE_ADMIN_PASSWORD" ] || [ -z "$SESAME_DATABASE_NAME" ] || [ -z "$SESAME_DATABASE_HOST" ] || [ -z "$SESAME_DATABASE_PORT" ]; then
+  echo "One or more required environment variables are not set in .env file. Please set them."
   exit 1
 fi
+
+SESAME_USER_ROLE=${SESAME_DATABASE_USER:-"sesame"}
+
+# Create a database URL 
+SESAME_DATABASE_ADMIN_URL="$SESAME_DATABASE_PROTOCOL://$SESAME_DATABASE_ADMIN_USER:$SESAME_DATABASE_ADMIN_PASSWORD@$SESAME_DATABASE_HOST:$SESAME_DATABASE_PORT/$SESAME_DATABASE_NAME"
 
 # Generate a random password for the anon user
 ANON_USER_PASSWORD=$(openssl rand -base64 16 | tr -dc 'a-zA-Z0-9')
 
 if [ -z "$ANON_USER_PASSWORD" ]; then
-  echo "Failed to generate password for anon_user from SESAME_DATABASE_URL."
+  echo "Failed to generate password for anon_user."
   exit 1
 fi
-
-# Create the SESAME_DATABASE_URL using the new role and password
-SESAME_DATABASE_URL=$(echo "$SESAME_DATABASE_ADMIN_URL" | sed -E "s|(postgresql://)[^.]+(\..+)?(:[^@]+)@|\1$SESAME_DATABASE_USER\2:$ANON_USER_PASSWORD@|")
 
 # Run schema with password substitution directly, passing the result to psql
 echo "Running schema on $SESAME_DATABASE_ADMIN_URL..."
@@ -45,5 +47,6 @@ fi
 
 echo "--------------------------------------------------"
 echo -e "\033[32mUpdate your server/.env to include:"
-echo -e "SESAME_DATABASE_URL=${SESAME_DATABASE_URL}\033[0m"
+echo -e "SESAME_DATABASE_USER=\"${SESAME_USER_ROLE}\""
+echo -e "SESAME_DATABASE_PASSWORD=\"${ANON_USER_PASSWORD}\"\033[0m"
 echo "--------------------------------------------------"

--- a/server/common/database.py
+++ b/server/common/database.py
@@ -30,7 +30,8 @@ def construct_database_url():
         )
 
     db_url = (
-        f"{os.getenv('SESAME_DATABASE_PROTOCOL', 'postgresql')}+asyncpg://://"
+        f"{os.getenv('SESAME_DATABASE_PROTOCOL', 'postgresql')}+"
+        f"{os.getenv('SESAME_DATABASE_ASYNC_DRIVER', 'asyncpg')}://"
         f"{os.getenv('SESAME_DATABASE_USER', 'postgres')}:"
         f"{os.getenv('SESAME_DATABASE_PASSWORD', 'postgres')}@"
         f"{os.getenv('SESAME_DATABASE_HOST', 'localhost')}:"
@@ -38,21 +39,10 @@ def construct_database_url():
         f"{os.getenv('SESAME_DATABASE_NAME', 'sesame')}"
     )
 
-    if db_url.startswith("postgresql://"):
-        db_url = db_url.replace("postgresql://", "postgresql+asyncpg://")
-
     return db_url
 
 
 DATABASE_URL = construct_database_url()
-
-if not DATABASE_URL:
-    raise ValueError(
-        "SESAME_DATABASE_URL is not set. Please set it in your .env file or environment variables."
-    )
-
-if DATABASE_URL.startswith("postgresql://"):
-    DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://")
 
 engine = create_async_engine(
     DATABASE_URL,

--- a/server/common/database.py
+++ b/server/common/database.py
@@ -11,7 +11,40 @@ load_dotenv()
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-DATABASE_URL = os.getenv("SESAME_DATABASE_URL")
+
+def construct_database_url():
+    required_vars = {
+        "SESAME_DATABASE_PROTOCOL": "postgresql",
+        "SESAME_DATABASE_USER": None,
+        "SESAME_DATABASE_PASSWORD": None,
+        "SESAME_DATABASE_HOST": None,
+        "SESAME_DATABASE_PORT": "5432",
+        "SESAME_DATABASE_NAME": "sesame",
+    }
+
+    missing_vars = [var for var, default in required_vars.items() if not os.getenv(var, default)]
+
+    if missing_vars:
+        raise ValueError(
+            f"Missing environment variables: {', '.join(missing_vars)}. Please set them in your .env file or environment variables."
+        )
+
+    db_url = (
+        f"{os.getenv('SESAME_DATABASE_PROTOCOL', 'postgresql')}+asyncpg://://"
+        f"{os.getenv('SESAME_DATABASE_USER', 'postgres')}:"
+        f"{os.getenv('SESAME_DATABASE_PASSWORD', 'postgres')}@"
+        f"{os.getenv('SESAME_DATABASE_HOST', 'localhost')}:"
+        f"{os.getenv('SESAME_DATABASE_PORT', '5432')}/"
+        f"{os.getenv('SESAME_DATABASE_NAME', 'sesame')}"
+    )
+
+    if db_url.startswith("postgresql://"):
+        db_url = db_url.replace("postgresql://", "postgresql+asyncpg://")
+
+    return db_url
+
+
+DATABASE_URL = construct_database_url()
 
 if not DATABASE_URL:
     raise ValueError(

--- a/server/env.example
+++ b/server/env.example
@@ -12,13 +12,19 @@ SESAME_RATE_LIMIT_WINDOW_MINUTES = 15
 #####################################
 #  Database
 #####################################
-# Enter your Supabase database URL here.
-# - Use a session port (transaction pooling)
-SESAME_DATABASE_ADMIN_URL="postgresql://user:password@url:5432/dbname"
+# Enter your database credentials here
+SESAME_DATABASE_ADMIN_USER=""
+SESAME_DATABASE_ADMIN_PASSWORD=""
+SESAME_DATABASE_NAME="sesame"
+SESAME_DATABASE_HOST=""
+# - Use a session port (typically 5432)
+SESAME_DATABASE_PORT=5432
 
 # --- Optional
-# Public role name
 SESAME_DATABASE_USER="sesame"
+# >>> Place SESAME_DATABASE_PASSWORD="" here
+
+SESAME_DATABASE_PROTOCOL="postgresql"
 # Echo SQL alchemy queries to stdout (recommended for debugging)
 # Set to 1 to enable echo 
 SESAME_DATABASE_ECHO_OUTPUT=0 

--- a/server/env.example
+++ b/server/env.example
@@ -27,6 +27,7 @@ SESAME_DATABASE_USER="sesame"
 SESAME_DATABASE_PASSWORD="" 
 
 SESAME_DATABASE_PROTOCOL="postgresql"
+SESAME_DATABASE_ASYNC_DRIVER="asyncpg"
 # Echo SQL alchemy queries to stdout (recommended for debugging)
 # Set to 1 to enable echo 
 SESAME_DATABASE_ECHO_OUTPUT=0 

--- a/server/env.example
+++ b/server/env.example
@@ -21,8 +21,10 @@ SESAME_DATABASE_HOST=""
 SESAME_DATABASE_PORT=5432
 
 # --- Optional
+# Public database role credentials
 SESAME_DATABASE_USER="sesame"
-# >>> Place SESAME_DATABASE_PASSWORD="" here
+# Note: this is generated when running bash scripts/run_schema.sh
+SESAME_DATABASE_PASSWORD="" 
 
 SESAME_DATABASE_PROTOCOL="postgresql"
 # Echo SQL alchemy queries to stdout (recommended for debugging)

--- a/server/webapp/api/rtvi.py
+++ b/server/webapp/api/rtvi.py
@@ -46,6 +46,7 @@ async def stream_action(
         )
 
     async def generate():
+        print("USER ID", user.user_id)
         async with get_authenticated_db_context(user) as db:
             config, conversation = await _get_config_and_conversation(params.conversation_id, db)
             messages = [msg.content for msg in conversation.messages]

--- a/server/webapp/main.py
+++ b/server/webapp/main.py
@@ -33,7 +33,7 @@ async def lifespan(app: FastAPI):
                 await conn.run_sync(Base.metadata.reflect)
     except Exception:
         logger.error(
-            "Database connection failed. Have you set a valid SESAME_DATABASE_URL in your server/.env?"
+            "Database connection failed. Have you set valid SESAME_DATABASE_* credentials in your server/.env?"
         )
     yield
     await engine.dispose()
@@ -77,7 +77,7 @@ async def home(request: Request):
             request,
             "error.html",
             {
-                "message": "Unable to connect to database. Have you set a valid SESAME_DATABASE_URL in your server/.env ?",
+                "message": "Database connection failed. Have you set valid SESAME_DATABASE_* credentials in your server/.env?"
             },
         )
 


### PR DESCRIPTION
It was very easy to make a mistake when setting a single `SESAME_DATABASE_URL`. This PR attempts to be more explicit by using individual database credential envs:

```
# Enter your database credentials here
SESAME_DATABASE_ADMIN_USER=""
SESAME_DATABASE_ADMIN_PASSWORD=""
SESAME_DATABASE_NAME="sesame"
SESAME_DATABASE_HOST=""
# - Use a session port (typically 5432)
SESAME_DATABASE_PORT=5432

# --- Optional
SESAME_DATABASE_USER="sesame"
# >>> Place SESAME_DATABASE_PASSWORD="" here
```