### PR TITLE
Improved message handling

### DIFF
--- a/client/web/app/[workspaceId]/ConversationListItem.tsx
+++ b/client/web/app/[workspaceId]/ConversationListItem.tsx
@@ -71,6 +71,7 @@ export default function ConversationListItem({
       });
       if (response.ok) {
         setIsEditing(false);
+        setIsUpdating(false);
         setTitle(title);
         refresh();
         emitter.emit("updateSidebar");
@@ -126,7 +127,7 @@ export default function ConversationListItem({
             <Tooltip open={updateFailed}>
               <TooltipTrigger asChild>
                 <Button
-                  className="absolute top-0 right-2"
+                  className="absolute top-1/2 -translate-y-1/2 right-1"
                   disabled={isUpdating}
                   size="icon"
                   type="submit"


### PR DESCRIPTION
# Short summary of changes (please include issue #)

This PR improves a few details in the live messages view:

- Filter out empty messages in the "middle" of the conversation (any empty message before the last)
- Removed text buffer. This was a workaround when bot messages weren't emitted in order.
- Mark bot message as final when bot TTS stopped
- Avoid choking user transcripts
- Removed storageItemStored event handler: this could lead to too much server-to-client state pushing upon data revalidation.