### PR TITLE
avoid leaking API keys to client

### DIFF
--- a/clients/web/app/api/create-workspace/route.ts
+++ b/clients/web/app/api/create-workspace/route.ts
@@ -6,6 +6,8 @@ import { NextRequest, NextResponse } from "next/server";
 export async function POST(request: NextRequest) {
   try {
     const workspace: WorkspaceModel = await request.json();
+    const apiKeys = structuredClone(workspace.config.api_keys ?? {});
+    delete workspace.config.api_keys;
 
     const apiClient = await getApiClient();
     const response = await apiClient.api.createWorkspaceApiWorkspacesPost({
@@ -16,7 +18,7 @@ export async function POST(request: NextRequest) {
     if (response.ok) {
       const json = await response.json();
 
-      await syncWorkspaceServices(json as WorkspaceModel);
+      await syncWorkspaceServices(json as WorkspaceModel, apiKeys);
 
       return NextResponse.json(json);
     } else {

--- a/clients/web/app/api/update-workspace/route.ts
+++ b/clients/web/app/api/update-workspace/route.ts
@@ -6,6 +6,8 @@ import { NextRequest, NextResponse } from "next/server";
 export async function PUT(request: NextRequest) {
   try {
     const workspace: WorkspaceModel = await request.json();
+    const apiKeys = structuredClone(workspace.config.api_keys ?? {});
+    delete workspace.config.api_keys;
 
     const apiClient = await getApiClient();
     const response =
@@ -20,7 +22,7 @@ export async function PUT(request: NextRequest) {
     if (response.ok) {
       const json = await response.json();
 
-      await syncWorkspaceServices(json as WorkspaceModel);
+      await syncWorkspaceServices(json as WorkspaceModel, apiKeys);
 
       return NextResponse.json(json);
     } else {

--- a/clients/web/lib/services.ts
+++ b/clients/web/lib/services.ts
@@ -32,16 +32,16 @@ interface ServiceConfig {
   workspaceId?: string;
 }
 
-export async function syncWorkspaceServices(workspace: WorkspaceModel) {
+export async function syncWorkspaceServices(workspace: WorkspaceModel, apiKeys: Record<string, string>) {
   const apiClient = await getApiClient();
   const services = await getServices();
 
   const map: Record<string, ServiceConfig> = {};
   Object.entries(serviceProviderTypeMap).forEach(([provider, type]) => {
-    if (!workspace.config.api_keys) return;
-    if (provider in workspace.config.api_keys) {
+    if (!apiKeys) return;
+    if (provider in apiKeys) {
       map[type] = {
-        apiKey: workspace.config.api_keys[provider],
+        apiKey: apiKeys[provider],
         provider,
         workspaceId: workspace.workspace_id,
       };

--- a/clients/web/lib/workspaces.ts
+++ b/clients/web/lib/workspaces.ts
@@ -18,10 +18,16 @@ export async function getWorkspaces() {
       `Error fetching workspaces: ${response.status} ${response.statusText}`
     );
   }
-  return (json as WorkspaceWithConversations[]).sort(
-    (a, b) =>
-      new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
-  );
+  return (json as WorkspaceWithConversations[])
+    .map((ws) => {
+      const cleanedUp = structuredClone(ws);
+      delete cleanedUp.config.api_keys;
+      return cleanedUp;
+    })
+    .sort(
+      (a, b) =>
+        new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+    );
 }
 
 export async function getWorkspace(id: string) {
@@ -31,7 +37,9 @@ export async function getWorkspace(id: string) {
       await apiClient.api.getWorkspaceApiWorkspacesWorkspaceIdGet(id);
     const json = await response.json();
     if (response.ok) {
-      return json as WorkspaceModel;
+      const cleanedUp = structuredClone<WorkspaceModel>(json);
+      delete cleanedUp.config.api_keys;
+      return cleanedUp;
     } else {
       throw new Error(
         `Error fetching workspace: ${response.status} ${response.statusText}`


### PR DESCRIPTION
# Short summary of changes (please include issue #)

This PR makes sure that API keys are not stored in a workspace's `config` anymore and that API keys are not returned to the client.